### PR TITLE
pagination added for query results

### DIFF
--- a/src/database.py
+++ b/src/database.py
@@ -240,18 +240,18 @@ class DatabaseManager:
             logger.error(f"Error inserting embeddings into '{table_name}': {str(e)}")
             raise
 
-    async def get_similar_rows(self, query_embedding: str, num_of_rows: int) -> List[Any]:
-        """Retrieve similar rows based on vector embedding similarity."""
+    async def get_similar_rows(self, query_embedding: str, num_of_rows: int, offset: int = 0) -> List[Any]:
+        """Retrieve similar rows based on vector embedding similarity with pagination."""
         sql = f"""
         SELECT table_name, row_data, embedding <=> CAST($1 AS vector) AS similarity
         FROM text_embeddings
         ORDER BY similarity ASC
-        LIMIT $2
+        LIMIT $2 OFFSET $3
         """
         try:
             async with self._conn.acquire() as conn:
                 async with conn.transaction():
-                    results = await conn.fetch(sql, query_embedding, num_of_rows)
+                    results = await conn.fetch(sql, query_embedding, num_of_rows, offset)
                     return results
         except Exception as e:
             logger.error(f"Error retrieving similar rows: {str(e)}")
@@ -317,4 +317,3 @@ class DatabaseManager:
         except Exception as e:
             logger.error(f"Error fetching schema: {str(e)}")
             raise
-    

--- a/src/vector.py
+++ b/src/vector.py
@@ -5,8 +5,8 @@ from src.config.settings import SENTENCE_TRANSFORMER_MODEL,VECTOR_ROWS_IN_PROMPT
 
 logger = logging.getLogger(__name__)
 
-async def get_similar_rows_from_vector(db: DatabaseManager, user_query: str, num_of_rows: int = VECTOR_ROWS_IN_PROMPT) -> tuple:
-    """Fetch similar rows using vector embeddings synchronously."""
+async def get_similar_rows_from_vector(db: DatabaseManager, user_query: str, num_of_rows: int = VECTOR_ROWS_IN_PROMPT, page: int = 1, page_size: int = 10) -> tuple:
+    """Fetch similar rows using vector embeddings synchronously with pagination."""
     try:
         embed_model = SentenceTransformer(SENTENCE_TRANSFORMER_MODEL)
         query_embedding = embed_model.encode(user_query)
@@ -14,8 +14,13 @@ async def get_similar_rows_from_vector(db: DatabaseManager, user_query: str, num
         embedding_str = '[' + ','.join(map(str, query_embedding)) + ']'
         results = await db.get_similar_rows(embedding_str, num_of_rows)
         logger.info("Similar rows retrieved")
-        
-        formatted_rows = "".join([f"Table: {row[0]}, Data: {row[1]}\n" for row in results])
+
+        # Implement pagination
+        start_index = (page - 1) * page_size
+        end_index = start_index + page_size
+        paginated_results = results[start_index:end_index]
+
+        formatted_rows = "".join([f"Table: {row[0]}, Data: {row[1]}\n" for row in paginated_results])
         return formatted_rows, user_query
     except Exception as e:
         logger.error(f"Error in vector search: {e}")

--- a/templates/text-to-sql.html
+++ b/templates/text-to-sql.html
@@ -1,93 +1,90 @@
 {% if message %}
-    <div class="message {% if type == 'error' %}error{% else %}success{% endif %}">
-        {{ message }}
-    </div>
+<div class="message {% if type == 'error' %}error{% else %}success{% endif %}">
+    {{ message }}
+</div>
 {% endif %}
 
 {% if sql_query %}
-    <div class="query-section">
-        <h3>Generated SQL Query</h3>
-        <div class="query-box">{{ sql_query }}</div>
-        
-        {% if query_token %}
-            <div class="actions-container">
-                <div class="action-group">
-                    <form class="action-form">
-                        <input type="hidden" name="query_token" value="{{ query_token }}">
-                        <button 
-                            hx-post="/execute-sql"
-                            hx-trigger="click"
-                            hx-target="#query-result"
-                            hx-include="[name='query_token']"
-                            type="button"
-                            class="primary-button"
-                        >
-                            <span>Execute Query</span>
-                            <span class="spinner htmx-indicator"></span>
-                        </button>
-                    </form>
-                </div>
+<div class="query-section">
+    <h3>Generated SQL Query</h3>
+    <div class="query-box">{{ sql_query }}</div>
 
-                <div class="feedback-group" id="feedback-group">
-                    <span class="feedback-label">Was this query correct?</span>
-                    <div class="feedback-buttons">
-                        <button 
-                            hx-post="/submit-feedback"
-                            hx-target="#feedback-result"
-                            hx-include="[name='query_token']"
-                            hx-vals='{"feedback": "yes"}'
-                            class="feedback-button yes"
-                        >
-                            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                                <polyline points="20 6 9 17 4 12"></polyline>
-                            </svg>
-                            Yes
-                        </button>
-                        <button 
-                            hx-post="/submit-feedback"
-                            hx-target="#feedback-result"
-                            hx-include="[name='query_token']"
-                            hx-vals='{"feedback": "no"}'
-                            class="feedback-button no"
-                        >
-                            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                                <line x1="18" y1="6" x2="6" y2="18"></line>
-                                <line x1="6" y1="6" x2="18" y2="18"></line>
-                            </svg>
-                            No
-                        </button>
-                    </div>
-                </div>
+    {% if query_token %}
+    <div class="actions-container">
+        <div class="action-group">
+            <form class="action-form">
+                <input type="hidden" name="query_token" value="{{ query_token }}">
+                <button hx-post="/execute-sql" hx-trigger="click" hx-target="#query-result"
+                    hx-include="[name='query_token']" type="button" class="primary-button">
+                    <span>Execute Query</span>
+                    <span class="spinner htmx-indicator"></span>
+                </button>
+            </form>
+        </div>
+
+        <div class="feedback-group" id="feedback-group">
+            <span class="feedback-label">Was this query correct?</span>
+            <div class="feedback-buttons">
+                <button hx-post="/submit-feedback" hx-target="#feedback-result" hx-include="[name='query_token']"
+                    hx-vals='{"feedback": "yes"}' class="feedback-button yes">
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <polyline points="20 6 9 17 4 12"></polyline>
+                    </svg>
+                    Yes
+                </button>
+                <button hx-post="/submit-feedback" hx-target="#feedback-result" hx-include="[name='query_token']"
+                    hx-vals='{"feedback": "no"}' class="feedback-button no">
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <line x1="18" y1="6" x2="6" y2="18"></line>
+                        <line x1="6" y1="6" x2="18" y2="18"></line>
+                    </svg>
+                    No
+                </button>
             </div>
-
-            <div id="feedback-result"></div>
-        {% endif %}
+        </div>
     </div>
+
+    <div id="feedback-result"></div>
+    {% endif %}
+</div>
 {% endif %}
 
 {% if column_names and results %}
-    <div class="results-section">
-        <h3>Query Results</h3>
-        <div class="table-container">
-            <table class="results-table">
-                <thead>
-                    <tr>
-                        {% for column in column_names %}
-                            <th data-column="{{ column }}">{{ column }}</th>
-                        {% endfor %}
-                    </tr>
-                </thead>
-                <tbody>
-                    {% for row in results %}
-                        <tr>
-                            {% for value in row %}
-                                <td title="{{ value }}">{{ value }}</td>
-                            {% endfor %}
-                        </tr>
+<div class="results-section">
+    <h3>Query Results</h3>
+    <div class="table-container">
+        <table class="results-table">
+            <thead>
+                <tr>
+                    {% for column in column_names %}
+                    <th data-column="{{ column }}">{{ column }}</th>
                     {% endfor %}
-                </tbody>
-            </table>
-        </div>
+                </tr>
+            </thead>
+            <tbody>
+                {% for row in results %}
+                <tr>
+                    {% for value in row %}
+                    <td title="{{ value }}">{{ value }}</td>
+                    {% endfor %}
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
     </div>
+</div>
 {% endif %}
 
+{% if similar_rows %}
+<div class="results-section">
+    <h3>Similar Rows</h3>
+    <pre>{{ similar_rows }}</pre>
+    <div class="pagination">
+        {% if page > 1 %}
+        <a href="?page={{ page - 1 }}&page_size={{ page_size }}" class="pagination-button">Previous</a>
+        {% endif %}
+        <span>Page {{ page }}</span>
+        <a href="?page={{ page + 1 }}&page_size={{ page_size }}" class="pagination-button">Next</a>
+    </div>
+</div>
+{% endif %}


### PR DESCRIPTION
Implemented pagination for query results in the get_similar_rows_from_vector function to handle large datasets efficiently and return results in manageable chunks.

in vector.py
Modified the get_similar_rows_from_vector function to include pagination logic.

in database.py
Updated to ensure the get_similar_rows method in DatabaseManager supports pagination by adding OFFSET and LIMIT clauses.

in routes.py
Modified the endpoint that calls get_similar_rows_from_vector to accept page and page_size as query parameters.

in text-to-sql.html
updated to add pagination controls to the template to allow users to navigate between pages.